### PR TITLE
Set working path to closest ancestor containing .git directory

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -99,6 +99,7 @@ if count(g:vimified_packages, 'general')
     " Use Ag over Grep
     set grepprg=ag\ --nogroup\ --nocolor
 
+    let g:ctrlp_working_path = 'r'
     let g:ctrlp_user_command = 'ag %s -i --nocolor --nogroup --ignore ".git" --ignore ".DS_Store" --hidden -g ""'
   else
     nnoremap <silent> <leader>F :ClearCtrlPCache<CR>\|:CtrlP<CR>


### PR DESCRIPTION
The default setting is `ra` which was scoping the search to the current directory first and then falling back to the closest ancestor containing `.git`
